### PR TITLE
Add link to Common Weakness Enumeration (CWE) in meta section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ If you're in a hurry or just don't like reading, here's a podcast-style breakdow
 * [Awesome Trustworthy AI](https://github.com/MinghuiChen43/awesome-trustworthy-deep-learning): list covering different topics in emerging research areas including but not limited to out-of-distribution generalization, adversarial examples, backdoor attack, model inversion attack, machine unlearning, &c.
 * [Awesome Responsible AI](https://github.com/AthenaCore/AwesomeResponsibleAI): a curated list of awesome academic research, books, code of ethics, courses, data sets, frameworks, institutes, maturity models, newsletters, principles, podcasts, reports, tools, regulations and standards related to Responsible, Trustworthy, and Human-Centered AI
 * [Awesome Safety Critical](https://github.com/stanislaw/awesome-safety-critical): a list of resources about programming practices for writing safety-critical software
+* [Common Weakness Enumeration (CWE)](https://cwe.mitre.org)
 
 ## About Us
 


### PR DESCRIPTION
Add a link to the Common Weakness Enumeration (CWE) website in the meta section of the `README.md`.

* Add a new link to [Common Weakness Enumeration (CWE)](https://cwe.mitre.org) under the existing links in the meta section.
* Ensure the link is listed in alphabetical order within the meta section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pedrosaunu/awesome-safety-critical-ai/pull/1?shareId=4fd8d4d7-7207-4095-85bf-abd2ce0f5b87).